### PR TITLE
Replays, lava, and starter pack support

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,6 +16,9 @@ console using the configuration set in the =game-runner= directory of
 the Entelect Challenge repo.  Change the configuration in that
 directory to change what game to play/watch.
 
+To watch a replay, run ~./watch-replay.sh <path-to-root-of-replay>~
+and it'll display the replay of the game.
+
 * Features
 
 ** History Scrolling
@@ -25,7 +28,7 @@ resume the live game, you can hit =r=.
 
 * Coming Soon (TM)
 
-** TODO Watch replays
+** DONE Watch replays
 ** DONE Scroll through history of game
    CLOSED: [2019-04-22 Mon 13:08]
    :LOGBOOK:

--- a/watch-game.el
+++ b/watch-game.el
@@ -127,7 +127,8 @@ If it's running from the console then quit Emacs too."
     (font-lock-add-keywords nil
                             '(("█"  . 'watch-hi-black-b)
                               ("▓"  . 'watch-hi-brown-b)
-                              ("╠╣" . 'hi-red-b)))
+                              ("╠╣" . 'hi-red-b)
+                              ("XX" . 'hi-red-b)))
     (kill-region (point-min) (point-max))
     (setq watch--previous-game-states nil)
     (setq watch--searching-through-history nil)

--- a/watch-game.el
+++ b/watch-game.el
@@ -142,7 +142,7 @@ To watch two different bots play against each other, change the
   configuration in that directory."
   (interactive "D(defaults to project in current dir): ")
   (progn
-    (let ((default-directory (format "%sgame-runner"
+    (let ((default-directory (format "%s"
                                      (or project-dir
                                          (car (project-roots (project-current)))))))
       (setq watch--process

--- a/watch-replay.sh
+++ b/watch-replay.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+emacs --no-init -nw --eval "(progn (load-file \"watch-game.el\") (watch-replay \"$1\"))"


### PR DESCRIPTION
- Shell script for calling the replay script
- Lava is now red
- Removed the embedded "game-runner" subdir, so you can call this with the pre-built starter pack. Otherwise you'd have to extract the starter pack to a dir called game-runner.  